### PR TITLE
Show useful description when events don't have one yet

### DIFF
--- a/_includes/calendar-js.html
+++ b/_includes/calendar-js.html
@@ -32,7 +32,7 @@
 					console.log(event);
 					var start = new Date( event.start.dateTime || event.start.date);
 					var end = new Date( event.end.dateTime || event.end.date);
-					html += '<li>'+renderEvent(event.summary, event.description, start,end) + '</li>';
+					html += '<li>'+renderEvent(event.summary, (event.description || "*More details to come*"), start,end) + '</li>';
 					if(i!=events.length-1)
 						html += '<hr>';
 				}


### PR DESCRIPTION
Instead of saying "undefined" it now says "More details to come". Not sure if you want to merge this - maybe it's better to "fail fast" and show `undefined` so you know to add a description to the event?

P.S. Love you work @e-e-e - this is a particularly awesome hack :sparkles: 