### PR TITLE
Fix bug making Feb funders not appear

### DIFF
--- a/_supporters/11.february.md
+++ b/_supporters/11.february.md
@@ -25,7 +25,6 @@ covered:
   - item: Risograph paper and ink
     value: 80
     name:
-
-* SPECIAL PUBLIC LIABILITY FUND *
-Thanks to: Marrickville School of Economics, Marietta Seale, Will Scott-Kemmis, Michelle Miller, Tiani Chillemi, Mel + Julia, Nick + Thomas, Naomi Riddle, Claire Field, Bettina Kaiser, Kathleen Lin, Sabrina Baker, Peter Williamson, Laura Fisher, OAF, April Pepper
+  - item: SPECIAL PUBLIC LIABILITY FUND
+    name: Marrickville School of Economics, Marietta Seale, Will Scott-Kemmis, Michelle Miller, Tiani Chillemi, Mel + Julia, Nick + Thomas, Naomi Riddle, Claire Field, Bettina Kaiser, Kathleen Lin, Sabrina Baker, Peter Williamson, Laura Fisher, OAF, April Pepper
 ---


### PR DESCRIPTION
The problem is that this final supporter, SPECIAL PUBLIC LIABILITY FUND
doesn't comply to the format for this file.

I've changed it to match the other values and it renders properly again. Here's how it appears now:

![screen shot 2017-02-10 at 9 59 35 pm](https://cloud.githubusercontent.com/assets/1239550/22824488/45ce5438-efdc-11e6-9866-bf6fcecdd6db.png)
