### PR TITLE
Update calendar-js to show past events by year.

### DIFF
--- a/_includes/calendar-js.html
+++ b/_includes/calendar-js.html
@@ -1,113 +1,155 @@
-<div id='calendar' data-year='{{include.year}}' data-month='{{include.month}}'>
-<noscript>Javascript is required to fetch upcoming events from the google calendar</noscript>
-<script type="text/javascript">
-	var cal = document.getElementById('calendar');
-	cal.innerHTML = '<h3 style="color:#555">Loading Events and Residents:</h3>';
-</script>
+<div id="calendar" data-year="{{ include.year }}">
+  <noscript
+    >Javascript is required to fetch upcoming events from the google
+    calendar</noscript
+  >
+  <script type="text/javascript">
+    var cal = document.getElementById("calendar");
+    cal.innerHTML = '<h3 style="color:#555">Loading Events and Residents:</h3>';
+  </script>
 </div>
 <script type="text/javascript" src="/js/micromarkdown.js"></script>
 <script type="text/javascript">
+  var days = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday"
+  ];
+  var months = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December"
+  ];
+  var calendar_id = "frontyardprojects@gmail.com";
 
-	var days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-	var months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
-	var calendar_id = 'frontyardprojects@gmail.com';
+  function loadCal() {
+    gapi.client.setApiKey("AIzaSyC-ETCMeqX_Hej9g-ihPGa69pdvFVCbfYg");
+    gapi.client.load("calendar", "v3", function() {
+      var cal = document.getElementById("calendar");
+      var year = cal.getAttribute("data-year");
+      if (year !== "") {
+        listEventsByYear(Math.floor(Number(year)));
+      } else {
+        listUpcomingEvents();
+      }
+    });
+  }
 
-	function loadCal() {
-		gapi.client.setApiKey('AIzaSyC-ETCMeqX_Hej9g-ihPGa69pdvFVCbfYg');
-		gapi.client.load('calendar', 'v3', function() {
-			var cal = document.getElementById('calendar');
-			var month = cal.getAttribute('data-month');
-			var year = cal.getAttribute('data-year');
-			console.log(typeof month, cal.getAttribute('data-month'));
-			if(year !== '' &&  month !== ''){
-				listEventsByMonth(Math.floor(Number(year)),Math.floor(Number(month)));
-			} else {
-				listUpcomingEvents();
-			}
-		});
-	}
+  function listEventsByYear(year, month) {
+    var endOfTheYear = new Date(year + 1, 0);
+    var now = new Date();
+    var isCurrentYear = endOfTheYear.getFullYear() === now.getFullYear();
+    listEvents(
+      {
+        calendarId: calendar_id,
+        timeMin: new Date(year, 0).toISOString(),
+        timeMax: isCurrentYear ? now.toISOString() : endOfTheYear.toISOString(),
+        showDeleted: false,
+        singleEvents: true,
+        maxResults: 300,
+        orderBy: "startTime"
+      },
+      "All Past Events",
+      true
+    );
+  }
 
-	function listEventsByMonth(year,month) {
-		listEvents({
-			'calendarId': calendar_id,
-			// 'timeMin': (new Date(year,month)).toISOString(),
-			'timeMax': (new Date()).toISOString(),//(new Date(year,month+1)).toISOString(),
-			'showDeleted': false,
-			'singleEvents': true,
-			'maxResults': 300,
-			'orderBy': 'startTime'
-		}, "All Past Events", true);
-	}
+  function listUpcomingEvents() {
+    listEvents(
+      {
+        calendarId: calendar_id,
+        timeMin: new Date().toISOString(),
+        showDeleted: false,
+        singleEvents: true,
+        maxResults: 25,
+        orderBy: "startTime"
+      },
+      "Upcoming Events and Residents"
+    );
+  }
 
-	function listUpcomingEvents() {
-		listEvents({
-				'calendarId': calendar_id,
-				'timeMin': (new Date()).toISOString(),
-				'showDeleted': false,
-				'singleEvents': true,
-				'maxResults': 25,
-				'orderBy': 'startTime'
-		}, "Upcoming Events and Residents");
-	}
+  function listEvents(options, heading, reverse) {
+    gapi.client.calendar.events.list(options).execute(function(resp) {
+      var events = resp.items;
+      var html = "<h3>" + heading + ":</h3>";
+      if (events.length > 0) {
+        html += "<ul>";
+        for (i = 0; i < events.length; i++) {
+          var event = events[reverse ? events.length - 1 - i : i];
+          var start = new Date(event.start.dateTime || event.start.date);
+          var end = new Date(event.end.dateTime || event.end.date);
+          html +=
+            "<li>" +
+            renderEvent(
+              event.summary,
+              event.description || "*More details to come*",
+              start,
+              end
+            ) +
+            "</li>";
+          if (i != events.length - 1) html += "<hr>";
+        }
+        html += "</ul>";
+      } else {
+        html += "<p>No events found.</p>";
+      }
+      var cal = document.getElementById("calendar");
+      cal.innerHTML = html;
+    });
+  }
 
-	function listEvents(options, heading, reverse) {
-		gapi.client.calendar.events.list(options)
-		.execute( function(resp) {
-			var events = resp.items;
-			var html = '<h3>'+heading+':</h3>';
-			if (events.length > 0) {
-				html += '<ul>';
-				for (i = 0; i < events.length; i++) {
-					var event = events[(reverse) ? events.length-1-i :i];
-					console.log(event);
-					var start = new Date( event.start.dateTime || event.start.date);
-					var end = new Date( event.end.dateTime || event.end.date);
-					html += '<li>'+renderEvent(event.summary, (event.description || "*More details to come*"), start,end) + '</li>';
-					if(i!=events.length-1)
-						html += '<hr>';
-				}
-				html += '</ul>';
-			} else {
-				html += '<p>No events found.</p>';
-			}
-			var cal = document.getElementById('calendar');
-			cal.innerHTML = html;
-		});
-	}
-	
-	function renderEvent(title, summary, start,end) {
-		var html = '<strong>'+title+'</strong></br><em>';
-		if((start.getMonth() !== end.getMonth()) || 
-			 (start.getYear() !== end.getYear()) ||
-			 (start.getDate() !== end.getDate()) ) {
-			html += prettyDate(start) +' –' +'</br>' + prettyDate(end);
-		} else {
-			html += prettyDate(start) + '</br>' + 
-							prettyTime(start) +' – ' + prettyTime(end);
-		}
-		html += '</em>';
-		try {
-			html += '<p>'+micromarkdown.parse(summary)+'</p>';
-		} catch (e) {
-			html += '<p>'+summary+'</p>';
-		}
-		return html;
-	}
+  function renderEvent(title, summary, start, end) {
+    var html = "<strong>" + title + "</strong></br><em>";
+    if (
+      start.getMonth() !== end.getMonth() ||
+      start.getYear() !== end.getYear() ||
+      start.getDate() !== end.getDate()
+    ) {
+      html += prettyDate(start) + " –" + "</br>" + prettyDate(end);
+    } else {
+      html +=
+        prettyDate(start) +
+        "</br>" +
+        prettyTime(start) +
+        " – " +
+        prettyTime(end);
+    }
+    html += "</em>";
+    try {
+      html += "<p>" + micromarkdown.parse(summary) + "</p>";
+    } catch (e) {
+      html += "<p>" + summary + "</p>";
+    }
+    return html;
+  }
 
-	function prettyDate(d) {
-		var month = months[d.getMonth()];
-		var day = days[d.getDay()]; 
-		var date = d.getDate();
-		var year = d.getFullYear();
-		return day+', ' + month + ' ' + date +', ' + year;
-	}
+  function prettyDate(d) {
+    var month = months[d.getMonth()];
+    var day = days[d.getDay()];
+    var date = d.getDate();
+    var year = d.getFullYear();
+    return day + ", " + month + " " + date + ", " + year;
+  }
 
-	function prettyTime(d) {
-		var h = d.getHours();
-		var m = d.getMinutes();
-		var t = (h>=12)?' PM':' AM';
-		if(h>12) h-=12;
-		return h+':'+((m<10)?'0':'')+m+t;
-	}
+  function prettyTime(d) {
+    var h = d.getHours();
+    var m = d.getMinutes();
+    var t = h >= 12 ? " PM" : " AM";
+    if (h > 12) h -= 12;
+    return h + ":" + (m < 10 ? "0" : "") + m + t;
+  }
 </script>
 <script src="https://apis.google.com/js/client.js?onload=loadCal"></script>

--- a/events/2016/index.md
+++ b/events/2016/index.md
@@ -1,0 +1,14 @@
+---
+title: "in 2016"
+---
+
+### Get involved:
+
+\*\*Frontyard\*\* aims to be an open and safe space - if you would like to host an event at frontyard please get in touch either via [email](mailto:frontyardprojects@gmail.com) or by coming along to one of our regular open house events. We have a simple application by conversation policy. **The space is free for unfunded and not-for-profit projects**, for everything else we have a standard rate sheet which applies. \*\*Frontyard\*\* is made possible by the [generous support of our community](/supporters).
+
+---
+
+{% include calendar-js.html year=2016 %}
+
+[View our full calendar](https://calendar.google.com/calendar/embed?src=frontyardprojects%40gmail.com&ctz=Australia/Sydney)
+or [add Frontyard to your own calendar](https://calendar.google.com/calendar/ical/frontyardprojects%40gmail.com/public/basic.ics).

--- a/events/2017/index.md
+++ b/events/2017/index.md
@@ -1,0 +1,14 @@
+---
+title: "in 2017"
+---
+
+### Get involved:
+
+\*\*Frontyard\*\* aims to be an open and safe space - if you would like to host an event at frontyard please get in touch either via [email](mailto:frontyardprojects@gmail.com) or by coming along to one of our regular open house events. We have a simple application by conversation policy. **The space is free for unfunded and not-for-profit projects**, for everything else we have a standard rate sheet which applies. \*\*Frontyard\*\* is made possible by the [generous support of our community](/supporters).
+
+---
+
+{% include calendar-js.html year=2017 %}
+
+[View our full calendar](https://calendar.google.com/calendar/embed?src=frontyardprojects%40gmail.com&ctz=Australia/Sydney)
+or [add Frontyard to your own calendar](https://calendar.google.com/calendar/ical/frontyardprojects%40gmail.com/public/basic.ics).

--- a/events/2018/index.md
+++ b/events/2018/index.md
@@ -1,15 +1,14 @@
 ---
-title: all past events
+title: "in 2018"
 ---
 
 ### Get involved:
 
 \*\*Frontyard\*\* aims to be an open and safe space - if you would like to host an event at frontyard please get in touch either via [email](mailto:frontyardprojects@gmail.com) or by coming along to one of our regular open house events. We have a simple application by conversation policy. **The space is free for unfunded and not-for-profit projects**, for everything else we have a standard rate sheet which applies. \*\*Frontyard\*\* is made possible by the [generous support of our community](/supporters).
 
------
+---
 
-{% include calendar-js.html month=5 year=2016 %}
+{% include calendar-js.html year=2018 %}
 
 [View our full calendar](https://calendar.google.com/calendar/embed?src=frontyardprojects%40gmail.com&ctz=Australia/Sydney)
 or [add Frontyard to your own calendar](https://calendar.google.com/calendar/ical/frontyardprojects%40gmail.com/public/basic.ics).
-

--- a/events/2019/index.md
+++ b/events/2019/index.md
@@ -1,0 +1,14 @@
+---
+title: "past in 2019"
+---
+
+### Get involved:
+
+\*\*Frontyard\*\* aims to be an open and safe space - if you would like to host an event at frontyard please get in touch either via [email](mailto:frontyardprojects@gmail.com) or by coming along to one of our regular open house events. We have a simple application by conversation policy. **The space is free for unfunded and not-for-profit projects**, for everything else we have a standard rate sheet which applies. \*\*Frontyard\*\* is made possible by the [generous support of our community](/supporters).
+
+---
+
+{% include calendar-js.html year=2019 %}
+
+[View our full calendar](https://calendar.google.com/calendar/embed?src=frontyardprojects%40gmail.com&ctz=Australia/Sydney)
+or [add Frontyard to your own calendar](https://calendar.google.com/calendar/ical/frontyardprojects%40gmail.com/public/basic.ics).


### PR DESCRIPTION
I noticed recently that our website does not show events between 2017 and now.
This is because we limited the past events page to 300 events. We obviously passed that a while ago.

#### Before: 
![image](https://user-images.githubusercontent.com/12589522/57300118-786c5f00-7119-11e9-8e82-13e5a83a5972.png)

#### After:
![image](https://user-images.githubusercontent.com/12589522/57300202-ad78b180-7119-11e9-94da-aac1484a50aa.png)
